### PR TITLE
set the executor's max queue size to 1000

### DIFF
--- a/resources/tomcat/conf/server.xml
+++ b/resources/tomcat/conf/server.xml
@@ -25,7 +25,7 @@
     </GlobalNamingResources>
 
     <Service name='Catalina'>
-        <Executor name="nioconnector" namePrefix="nioconnector" maxIdleTime="10000" prestartminSpareThreads="true" maxThreads="384" minSpareThreads="64"/>
+        <Executor name="nioconnector" namePrefix="nioconnector" maxQueueSize="1000" maxIdleTime="10000" prestartminSpareThreads="true" maxThreads="384" minSpareThreads="64"/>
         <Connector executor="nioconnector" maxThreads="384" minSpareThreads="64" server="Redacted" port='${http.port}' bindOnInit="false" protocol="org.apache.coyote.http11.Http11NioProtocol" compression="on" compressionMinSize="1024" compressableMimeType="application/json,text/html,text/xml" maxConnections="10000" connectionTimeout="30000" keepAliveTimeout="30000" maxKeepAliveRequests="-1" maxHeaderCount="-1" maxParameterCount="-1" maxPostSize="-1" maxSavePostSize="-1"/>
 
         <Engine defaultHost='localhost' name='Catalina'>


### PR DESCRIPTION
This is lower than the default of Integer.MAX_VALUE. Note that I didn't set Connector's acceptCount
to anything special, since it defaults to 100 anyways. I'm not sure if they're additive or not.